### PR TITLE
NVDA conflicting with D-Link connection manager

### DIFF
--- a/NVDA Issue
+++ b/NVDA Issue
@@ -1,0 +1,2 @@
+# NVDA-
+NVDA conflicting with D-Link connection manager


### PR DESCRIPTION
I have been encountering this problem with my NVDA. Each time I turn on my D-Link connection manager my screen reader cannot read the files inside My Documents folder anymore. I have to turn off my D-Link for my NVDA to function properly again. I have already tried using the registry patch I found on one of the threads here and also re-installed my D-Link connection manager but the issue still persist. Can anyone suggest a possible solutions for this please?